### PR TITLE
fix: don't autostart if started from vscode

### DIFF
--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -58,7 +58,7 @@ alias tmux=_fish_tmux_plugin_run
 
 set -q fish_tmux_autostarted || set fish_tmux_autostarted false
 if status is-interactive && ! fish_is_root_user
-    if test -z $TMUX && test $fish_tmux_autostart = true && test -z $INSIDE_EMACS && test -z $EMACS && test -z $VIM
+    if test -z $TMUX && test $fish_tmux_autostart = true && test -z $INSIDE_EMACS && test -z $EMACS && test -z $VIM && test ! $TERM_PROGRAM = 'vscode'
         if test $fish_tmux_autostart_once = false || test ! $fish_tmux_autostarted = true
             set -x fish_tmux_autostarted true
             _fish_tmux_plugin_run


### PR DESCRIPTION
If `fish_tmux_autostart = true` (which is the default) and vscode is configured to to use fish with the integrated terminal with something like:

```json
"terminal.integrated.profiles.osx": {
    "tmux": {
      "path": "/opt/homebrew/bin/fish",
      "args": [
        "--login",
        "--interactive",
        "-c",
        "tmux new -ADs 'vscode'"
      ],
      "icon": "terminal-tmux"
    },
    "fish": {
      "path": "/opt/homebrew/bin/fish",
      "args": [
        "--login",
        "--interactive",
      ]
    }
  },
  "terminal.integrated.defaultProfile.osx": "fish",
```

then VSCode will fail to resolve the shell environment:

![image](https://user-images.githubusercontent.com/25483483/215262569-2ffe90ad-9b4f-4e51-93f1-0dfcad92b807.png)

This fixes the issue by not autostarting tmux the same way that is currently done for VIM and emcas.
