### PR TITLE
fix: check `VSCODE_RESOLVING_ENVIRONMENT` env variable

### DIFF
--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -58,7 +58,13 @@ alias tmux=_fish_tmux_plugin_run
 
 set -q fish_tmux_autostarted || set fish_tmux_autostarted false
 if status is-interactive && ! fish_is_root_user
-    if test -z $TMUX && test $fish_tmux_autostart = true && test -z $INSIDE_EMACS && test -z $EMACS && test -z $VIM && test "$TERM_PROGRAM" != 'vscode'
+    if test -z $TMUX && \
+        test $fish_tmux_autostart = true && \
+        test -z $INSIDE_EMACS && \
+        test -z $EMACS && \
+        test -z $VIM && \
+        test -z $VSCODE_RESOLVING_ENVIRONMENT && \
+        test "$TERM_PROGRAM" != 'vscode'
         if test $fish_tmux_autostart_once = false || test ! $fish_tmux_autostarted = true
             set -x fish_tmux_autostarted true
             _fish_tmux_plugin_run


### PR DESCRIPTION
The January 2023 release of VSCode added a new `VSCODE_RESOLVING_ENVIRONMENT` variable (https://code.visualstudio.com/updates/v1_75#_new-vscoderesolvingenvironment-environment-variable) that is set to 1 when resolving user's shell environment.

Related to #1, this fixes the same issue for VSCode version >= 1.75.