### PR TITLE
Add extra check for macos

### DIFF
--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -1,6 +1,14 @@
 if not type -q tmux
-    echo "fish tmux plugin: tmux not found. Please install tmux before using this plugin." >&2
-    exit 1
+    switch (uname)
+        case Darwin
+            if test -q /opt/homebrew/bin/brew
+                echo "Attempting to load homebrew." >&2
+                eval $(/opt/homebrew/bin/brew shellenv)
+            end
+        case '*'
+            echo "fish tmux plugin: tmux not found. Please install tmux before using this plugin." >&2
+            exit 1
+    end
 end
 
 set -q fish_tmux_autostart || set fish_tmux_autostart true

--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -1,15 +1,22 @@
-if not type -q tmux
-    switch (uname)
-        case Darwin
-            if test -q /opt/homebrew/bin/brew
-                echo "Attempting to load homebrew." >&2
-                eval $(/opt/homebrew/bin/brew shellenv)
-            end
-        case '*'
-            echo "fish tmux plugin: tmux not found. Please install tmux before using this plugin." >&2
-            exit 1
-    end
+switch (uname)
+    case "Linux"
+        if test -d /home/linuxbrew
+            set -gx PATH "/home/homebrew/bin" "/home/homebrew/sbin" $PATH
+        end
+    case "Darwin"
+        if test -d /opt/homebrew
+            set -gx PATH "/opt/linuxbrew/bin" "/opt/linuxbrew/sbin" $PATH
+        end
+        # Not sure if this is needed though because on Linux /usr/local is in the PATH by default
+        if test -d /usr/local
+            set -gx PATH "/usr/local/bin" "/usr/local/sbin" $PATH
+        end
 end
+
+if not type -q tmux 
+     echo "fish tmux plugin: tmux not found. Please install tmux before using this plugin." >&2 
+     exit 1 
+ end 
 
 set -q fish_tmux_autostart || set fish_tmux_autostart true
 set -q fish_tmux_autostart_once || set fish_tmux_autostart_once true


### PR DESCRIPTION
Following conversation at https://github.com/budimanjojo/tmux.fish/issues/4 
This is still a workaround. What it does is check if homebrew is installed (assuming it's installed in the default location) in mac or linux.

Again, this is a workaround because the right thing would be to figure out what's the right way to let fisher plugin "Wait" until homebrew has loaded.