### PR TITLE
fix: append correct homebrew PATH on Darwin

### DIFF
--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -1,7 +1,7 @@
 switch (uname)
     case "Linux"
         if test -d /home/linuxbrew
-            set -gx PATH "/home/homebrew/bin" "/home/homebrew/sbin" $PATH
+            set -gx PATH "/home/linuxbrew/bin" "/home/linuxbrew/sbin" $PATH
         end
     case "Darwin"
         if test -d /opt/homebrew

--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -5,7 +5,7 @@ switch (uname)
         end
     case "Darwin"
         if test -d /opt/homebrew
-            set -gx PATH "/opt/linuxbrew/bin" "/opt/linuxbrew/sbin" $PATH
+            set -gx PATH "/opt/homebrew/bin" "/opt/homebrew/sbin" $PATH
         end
         # Not sure if this is needed though because on Linux /usr/local is in the PATH by default
         if test -d /usr/local

--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -13,10 +13,10 @@ switch (uname)
         end
 end
 
-if not type -q tmux 
-     echo "fish tmux plugin: tmux not found. Please install tmux before using this plugin." >&2 
-     exit 1 
- end 
+if not type -q tmux
+     echo "fish tmux plugin: tmux not found. Please install tmux before using this plugin." >&2
+     exit 1
+ end
 
 set -q fish_tmux_autostart || set fish_tmux_autostart true
 set -q fish_tmux_autostart_once || set fish_tmux_autostart_once true


### PR DESCRIPTION
Linux and MacOS paths were mixed up, use `/opt/linuxbew` on linux and `/opt/homebrew` on Darwin