### PR TITLE
feat: add `fish_tmux_alter_path` config variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ fisher install budimanjojo/tmux.fish
 | `fish_tmux_autostart`               | Automatically starts tmux (default: `true`)                                               |
 | `fish_tmux_autostart_once`          | Autostart only if tmux hasn't been started previously (default: `true`)                   |
 | `fish_tmux_autoconnect`             | Automatically connect to previous session if it exits (default: `true`)                   |
+| `fish_tmux_alter_path`              | Alter `$PATH` to include homebrew `bin` and `sbin` folders (default: `true`)              |
 | `fish_tmux_fixterm`                 | Sets `$TERM` to 256-color term or not based on current terminal support (default: `true`) |
 | `fish_tmux_iterm2`                  | Sets the `-CC` option for iTerm2 tmux integration (default: `false`)                      |
 | `fish_tmux_fixterm_without_256color`| `$TERM` to use for non 256-color terminals (default: `screen`)                            |

--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -1,22 +1,26 @@
-switch (uname)
-    case "Linux"
-        if test -d /home/linuxbrew
-            set -gx PATH "/home/linuxbrew/bin" "/home/linuxbrew/sbin" $PATH
-        end
-    case "Darwin"
-        if test -d /opt/homebrew
-            set -gx PATH "/opt/homebrew/bin" "/opt/homebrew/sbin" $PATH
-        end
-        # Not sure if this is needed though because on Linux /usr/local is in the PATH by default
-        if test -d /usr/local
-            set -gx PATH "/usr/local/bin" "/usr/local/sbin" $PATH
-        end
+set -q fish_tmux_alter_path || set fish_tmux_alter_path true
+
+if test fish_tmux_alter_path = true
+    switch (uname)
+        case "Linux"
+            if test -d /home/linuxbrew
+                set -gx PATH "/home/linuxbrew/bin" "/home/linuxbrew/sbin" $PATH
+            end
+        case "Darwin"
+            if test -d /opt/homebrew
+                set -gx PATH "/opt/homebrew/bin" "/opt/homebrew/sbin" $PATH
+            end
+            # Not sure if this is needed though because on Linux /usr/local is in the PATH by default
+            if test -d /usr/local
+                set -gx PATH "/usr/local/bin" "/usr/local/sbin" $PATH
+            end
+    end
 end
 
 if not type -q tmux
      echo "fish tmux plugin: tmux not found. Please install tmux before using this plugin." >&2
      exit 1
- end
+end
 
 set -q fish_tmux_autostart || set fish_tmux_autostart true
 set -q fish_tmux_autostart_once || set fish_tmux_autostart_once true


### PR DESCRIPTION
The variable controls whether to change `PATH` automatically or not. To preserve the existing behavior the variable default to true. This change gives the user control over their `PATH`. For example, when using the `asdf` version manager and homebrew in parallel, one would want to have `~/.asdf/bin` folder before `/opt/homebrew/bin` on `PATH`.