### PR TITLE
Do not run tmux in a JetBrains IDEs integrated terminal

### DIFF
--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -83,7 +83,8 @@ if status is-interactive && ! fish_is_root_user
         test -z $EMACS && \
         test -z $VIM && \
         test -z $VSCODE_RESOLVING_ENVIRONMENT && \
-        test "$TERM_PROGRAM" != 'vscode'
+        test "$TERM_PROGRAM" != 'vscode' && \
+        test "$TERMINAL_EMULATOR" != 'JetBrains-JediTerm'
         if test $fish_tmux_autostart_once = false || test ! $fish_tmux_autostarted = true
             set -x fish_tmux_autostarted true
             _fish_tmux_plugin_run


### PR DESCRIPTION
Treat the JetBrains IDEs integrated terminals the same as VSCode, vim, etc.