### PR TITLE
Do not run tmux in a Zed integrated terminal

### DIFF
--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -84,6 +84,7 @@ if status is-interactive && ! fish_is_root_user
         test -z $VIM && \
         test -z $VSCODE_RESOLVING_ENVIRONMENT && \
         test "$TERM_PROGRAM" != 'vscode' && \
+        test "$TERM_PROGRAM" != 'zed' && \
         test "$TERMINAL_EMULATOR" != 'JetBrains-JediTerm'
         if test $fish_tmux_autostart_once = false || test ! $fish_tmux_autostarted = true
             set -x fish_tmux_autostarted true


### PR DESCRIPTION
Same as #9 but for [Zed](https://github.com/zed-industries/zed).

Zed IDE sets `TERM_PROGRAM` to 'zed'.

See: https://github.com/zed-industries/zed/blob/a850731b0ed61b0ef2a0173843b6daedf45327e8/crates/terminal/src/terminal.rs#L328