### PR TITLE
feat!: make this plugin works like upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,18 @@
 
 </div>
 
-This is a [tmux](https://github.com/tmux/tmux) plugin for [fish](https://fishshell.com/). Inspired by or rather a port of [ohmyzsh tmux plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/tmux).
+> [!NOTE]
+> There are breaking changes before v2 which is basically a complete rewrite. This plugin was not one to one port of [ohmyzsh tmux plugin](https://github.com/ohmyzsh/tree/master/plugins/tmux) before v2. After v2 (including this main branch) this plugin works and behaves exactly like the zsh plugin. See [this for more information](https://github.com/budimanjojo/tmux.fish/issues/12).
+
+This is a [tmux](https://github.com/tmux/tmux) plugin for [fish](https://fishshell.com/). It is port of [ohmyzsh tmux plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/tmux) but for Fish shell.
 
 ## Features
 
 This plugin does the following:
 
 - determines if tmux is installed or not, if not, prompt user to install tmux
-- autostart/autoconnect tmux by default
 - determines if the terminal supports the 256 colors or not, sets the appropriate configuration variable
 - sets the correct local config file to use
-- abbrereviations for tmux
 
 ## Installation
 
@@ -23,46 +24,55 @@ First, make sure you have the recent version of tmux and fish as I don't test th
 fisher install budimanjojo/tmux.fish
 ```
 
-## Abbreviations
+## Aliases
 
-| Alias  | Command                | Description                                               |
-| ------ | -----------------------|---------------------------------------------------------- |
-| `ta`   | tmux attach -t         | Attach new tmux session to already running named session  |
-| `tad`  | tmux attach -d -t      | Detach named tmux session                                 |
-| `ts`   | tmux new-session -s    | Create a new named tmux session                           |
-| `tl`   | tmux list-sessions     | Displays a list of running tmux sessions                  |
-| `tksv` | tmux kill-server       | Terminate all running tmux sessions                       |
-| `tkss` | tmux kill-session -t   | Terminate named running tmux session                      |
+| Alias      | Command                        | Description                                               |
+| ---------- | -------------------------------|---------------------------------------------------------- |
+| `ta`       | tmux attach -t                 | Attach new tmux session to already running named session  |
+| `tad`      | tmux attach -d -t              | Detach named tmux session                                 |
+| `tds`      | `_fish_tmux_directory_session` | Creates or attaches to a session for the current path     |
+| `tkss`     | tmux kill-session -t           | Terminate named running tmux session                      |
+| `tksv`     | tmux kill-server               | Terminate all running tmux sessions                       |
+| `tl`       | tmux list-sessions             | Displays a list of running tmux sessions                  |
+| `tmux`     | `_fish_tmux_plugin_run`        | Start a new tmux session                                  |
+| `tmuxconf` | `$EDITOR $fish_tmux_config`    | Open .tmux.conf file with an editor                       |
+| `ts`       | tmux new-session -s            | Create a new named tmux session                           |
 
 ## Configuration Variables
 
-| Variable                            | Description                                                                               |
-|-------------------------------------|-------------------------------------------------------------------------------------------|
-| `fish_tmux_autostart`               | Automatically starts tmux (default: `true`)                                               |
-| `fish_tmux_autostart_once`          | Autostart only if tmux hasn't been started previously (default: `true`)                   |
-| `fish_tmux_autoconnect`             | Automatically connect to previous session if it exits (default: `true`)                   |
-| `fish_tmux_alter_path`              | Alter `$PATH` to include homebrew `bin` and `sbin` folders (default: `true`)              |
-| `fish_tmux_fixterm`                 | Sets `$TERM` to 256-color term or not based on current terminal support (default: `true`) |
-| `fish_tmux_iterm2`                  | Sets the `-CC` option for iTerm2 tmux integration (default: `false`)                      |
-| `fish_tmux_fixterm_without_256color`| `$TERM` to use for non 256-color terminals (default: `screen`)                            |
-| `fish_tmux_fixterm_with_256color`   | `$TERM` to use for 256-color terminals (default: `screen-256color`                        |
-| `fish_tmux_config`                  | Set the configuration path (default: `$HOME/.tmux.conf`)                                  |
-| `fish_tmux_unicode`                 | Set `tmux -u` option to support unicode (default: `false`)                                |
-| `fish_tmux_default_session_name`    | Set tmux default session name when autostart is enabled                                   |
+| Variable                            | Description                                                                                                 |
+|-------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| `fish_tmux_autostart`               | Automatically starts tmux (default: `false`)                                                                |
+| `fish_tmux_autostart_once`          | Autostart only if tmux hasn't been started previously (default: `true`)                                     |
+| `fish_tmux_autoconnect`             | Automatically connect to previous session if it exits (default: `true`)                                     |
+| `fish_tmux_autoquit`                | Automatically closes terminal once tmux exits (default: `fish_tmux_autostart`)                              |
+| `fish_tmux_config`                  | Set the configuration path (default: `$HOME/.tmux.conf`, `$XDG_CONFIG_HOME/tmux/tmux.conf`)                 |
+| `fish_tmux_default_session_name`    | Set tmux default session name when autostart is enabled                                                     |
+| `fish_tmux_autoname_session`        | Automatically name new sessions based on the basename of `$PWD` (default: `false`)                          |
+| `fish_tmux_detached`                | Set the detached mode (default: `false`)                                                                    |
+| `fish_tmux_fixterm`                 | Sets `$TERM` to 256-color term or not based on current terminal support (default: `true`)                   |
+| `fish_tmux_fixterm_without_256color`| `$TERM` to use for non 256-color terminals (default: `tmux` if available, `screen` otherwise)               |
+| `fish_tmux_fixterm_with_256color`   | `$TERM` to use for 256-color terminals (default: `tmux-256color` if available, `screen-256color` otherwise) |
+| `fish_tmux_iterm2`                  | Sets the `-CC` option for iTerm2 tmux integration (default: `false`)                                        |
+| `fish_tmux_unicode`                 | Set `tmux -u` option to support unicode (default: `false`)                                                  |
 
 ## Configuration
 
-You can modify the default configuration variables either by exporting the env from your `config.fish` or in your terminal, for example:
+You can modify the default configuration variables either by exporting the env from your `config.fish` or in your terminal.
+To autostart `tmux` when you open your terminal, you can put something like this in your `config.fish`:
+
 ```
-set -Ux fish_tmux_config $HOME/.config/tmux.conf
+status is-interactive; and begin
+    set fish_tmux_autostart true
+end
 ```
+
+Remember to order the `set` command after `$PATH` is set correctly for `tmux` command so the plugin can it.
 
 ## Difference with ZSH Version
 
-- Autostart is set to `true` by default
-- Automatically closes terminal once tmux exits is hardcoded because I can't get the zsh way working in fish (maybe some help?)
-- This plugin will only run if the user is not root. This is to avoid having nested tmux from the same environment
-- Alias is now abbrereviations
+- Autostart is a [fish function](https://fishshell.com/docs/current/cmds/function.html) with `--on-variable` option. This means the autostart will run as soon as you change the variable `$fish_tmux_autostart` to `true`. This lets you decide when to start the function. This is needed due to how `fish` handle the order of execution. Fish will always load everything inside `$__fish_config_dir/conf.d` before running user config. This leads to issue such as [tmux not found](https://github.com/budimanjojo/tmux.fish/issues/4).
+- Most configuration variables are local to the function when being run. So your current shell won't be filled with `fish_tmux_xxx` variables.
 
 ## License
 MIT License

--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -11,13 +11,38 @@ else
 end
 
 # aliases
+function _build_tmux_alias
+    set alias_name $argv[1]
+    set tmux_cmd $argv[2]
+    set ts_flag $argv[3]
+    set full_cmd "command tmux $tmux_cmd $ts_flag"
+
+    eval "
+    function $alias_name --wraps='$full_cmd' --description 'alias $alias_name=$full_cmd'
+        # check if the first argument for this function is empty or starts with '-'
+        if test (count \$argv) -eq 0 || test (string sub -l 1 \$argv[1]) = '-'
+            command tmux $tmux_cmd \$argv
+        else
+            $full_cmd \$argv
+        end
+    end
+    "
+end
+
+alias tmux=_fish_tmux_plugin_run
+alias tds=_fish_tmux_directory_session
 alias tksv="command tmux kill-server"
 alias tl="command tmux list-sessions"
 alias tmuxconf="$EDITOR $fish_tmux_config"
-alias ta="command tmux attach -t"
-alias tad="command tmux attach -d -t"
-alias ts="command tmux new-session -s"
-alias tkss="command tmux kill-session -t"
+# `-t` and `-s` flag for tmux commands require argument
+# so we remove the flag when called without argument and run normally when called with argument
+# see: https://github.com/ohmyzsh/ohmyzsh/issues/12230
+_build_tmux_alias "ta" "attach" "-t"
+_build_tmux_alias "tad" "attach -d" "-t"
+_build_tmux_alias "ts" "new-session" "-s"
+_build_tmux_alias "tkss" "kill-session" "-t"
+
+functions -e _build_tmux_alias # remove this function after use
 
 # wrapper function for tmux
 function _fish_tmux_plugin_run
@@ -115,8 +140,6 @@ function _fish_tmux_plugin_run
     end
 end
 
-alias tmux=_fish_tmux_plugin_run
-
 function _fish_tmux_directory_session
     # current directory without leading path
     set dir (basename $PWD)
@@ -127,8 +150,6 @@ function _fish_tmux_directory_session
     # create or attach to the session
     tmux new -As "$session_name"
 end
-
-alias tds=_fish_tmux_directory_session
 
 # this will autostart tmux if $fish_tmux_autostart is set to `true` using the `--on-variable` function option
 function _fish_tmux_plugin_run_autostart --on-variable fish_tmux_autostart

--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -11,13 +11,13 @@ else
 end
 
 # aliases
-alias tksv="tmux kill-server"
-alias tl="tmux list-sessions"
+alias tksv="command tmux kill-server"
+alias tl="command tmux list-sessions"
 alias tmuxconf="$EDITOR $fish_tmux_config"
-alias ta="tmux attach -t"
-alias tad="tmux attach -d -t"
-alias ts="tmux new-session -s"
-alias tkss="tmux kill-session -t"
+alias ta="command tmux attach -t"
+alias tad="command tmux attach -d -t"
+alias ts="command tmux new-session -s"
+alias tkss="command tmux kill-session -t"
 
 # wrapper function for tmux
 function _fish_tmux_plugin_run

--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -1,93 +1,152 @@
-set -q fish_tmux_alter_path || set fish_tmux_alter_path true
-
-if test fish_tmux_alter_path = true
-    switch (uname)
-        case "Linux"
-            if test -d /home/linuxbrew
-                set -gx PATH "/home/linuxbrew/bin" "/home/linuxbrew/sbin" $PATH
-            end
-        case "Darwin"
-            if test -d /opt/homebrew
-                set -gx PATH "/opt/homebrew/bin" "/opt/homebrew/sbin" $PATH
-            end
-            # Not sure if this is needed though because on Linux /usr/local is in the PATH by default
-            if test -d /usr/local
-                set -gx PATH "/usr/local/bin" "/usr/local/sbin" $PATH
-            end
-    end
-end
-
-if not type -q tmux
-     echo "fish tmux plugin: tmux not found. Please install tmux before using this plugin." >&2
-     exit 1
-end
-
-set -q fish_tmux_autostart || set fish_tmux_autostart true
-set -q fish_tmux_autostart_once || set fish_tmux_autostart_once true
-set -q fish_tmux_autoconnect || set fish_tmux_autoconnect true
-set -q fish_tmux_autoquit || set fish_tmux_autoquit $fish_tmux_autostart
-set -q fish_tmux_fixterm || set fish_tmux_fixterm true
-set -q fish_tmux_iterm2 || set fish_tmux_iterm2 false
-set -q fish_tmux_fixterm_without_256color || set fish_tmux_fixterm_without_256color "screen"
-set -q fish_tmux_fixterm_with_256color || set fish_tmux_fixterm_with_256color "screen-256color"
-set -q fish_tmux_config || set -x fish_tmux_config "$HOME/.tmux.conf"
-set -q fish_tmux_unicode || set fish_tmux_unicode false
-
-if test (tput colors) = "256"
-    set -x fish_tmux_term $fish_tmux_fixterm_with_256color
+# global variables
+set -q fish_tmux_autostart || set -g fish_tmux_autostart false
+set -q fish_tmux_autostarted || set -gx fish_tmux_autostarted false
+# set the configuration path
+if test -e "$HOME/.tmux.conf"
+    set -q fish_tmux_config || set -gx fish_tmux_config "$HOME/.tmux.conf"
+else if test -e (set -q XDG_CONFIG_HOME || echo "$HOME/.config")/tmux/tmux.conf
+    set -q fish_tmux_config || set -gx fish_tmux_config (set -q XDG_CONFIG_HOME || echo "$HOME/.config")/tmux/tmux.conf
 else
-    set -x fish_tmux_term $fish_tmux_fixterm_without_256color
+    set -q fish_tmux_config || set -gx fish_tmux_config "$HOME/.tmux.conf"
 end
 
-set -l script_dir (realpath (dirname (status -f)))
-if test ! $fish_tmux_iterm2 = true && test -e $fish_tmux_config
-    set -x _fish_tmux_fixed_config "$script_dir/tmux.extra.conf"
-else
-    set -x _fish_tmux_fixed_config "$script_dir/tmux.only.conf"
-end
+# aliases
+alias tksv="tmux kill-server"
+alias tl="tmux list-sessions"
+alias tmuxconf="$EDITOR $fish_tmux_config"
+alias ta="tmux attach -t"
+alias tad="tmux attach -d -t"
+alias ts="tmux new-session -s"
+alias tkss="tmux kill-session -t"
 
+# wrapper function for tmux
 function _fish_tmux_plugin_run
+    if not type -q tmux
+        echo "fish tmux plugin: tmux not found. Please install tmux before using this plugin." >&2
+        exit 1
+    end
+
+    set -q fish_tmux_autoquit || set fish_tmux_autoquit $fish_tmux_autostart
+    set -q fish_tmux_autoconnect || set fish_tmux_autoconnect true
+    set -q fish_tmux_autoname_session || set fish_tmux_autoname_session false
+    set -q fish_tmux_detached || set fish_tmux_detached false
+    set -q fish_tmux_fixterm || set fish_tmux_fixterm true
+    set -q fish_tmux_iterm2 || set fish_tmux_iterm2 false
+    set -q fish_tmux_unicode || set fish_tmux_unicode false
+
+    if test -e /usr/share/terminfo/t/tmux
+        set -q fish_tmux_fixterm_without_256color || set fish_tmux_fixterm_without_256color "tmux"
+    else
+        set -q fish_tmux_fixterm_without_256color || set fish_tmux_fixterm_without_256color "screen"
+    end
+
+    if test -e /usr/share/terminfo/t/tmux-256color
+        set -q fish_tmux_fixterm_with_256color || set fish_tmux_fixterm_with_256color "tmux-256color"
+    else
+        set -q fish_tmux_fixterm_with_256color || set fish_tmux_fixterm_with_256color "screen-256color"
+    end
+
+    # determine if the terminal supports 256 color
+    if test (tput colors) = "256"
+        set -gx fish_tmux_term $fish_tmux_fixterm_with_256color
+    else
+        set -gx fish_tmux_term $fish_tmux_fixterm_without_256color
+    end
+
+    # set the correct local config file to use
+    set script_dir (realpath (dirname (status -f)))
+    if test ! "$fish_tmux_iterm2" = true && test -e "$fish_tmux_config"
+        set _fish_tmux_fixed_config "$script_dir/tmux.extra.conf"
+    else
+        set _fish_tmux_fixed_config "$script_dir/tmux.only.conf"
+    end
+
+    # wrapper starts here
     if test (count $argv) -gt 0
         command tmux $argv
         return $status
     end
 
-    set -l tmux_cmd tmux
-    test $fish_tmux_iterm2 = true && set -a tmux_cmd -CC
-    test $fish_tmux_unicode = true && set -a tmux_cmd -u
+    set tmux_cmd tmux
+    test "$fish_tmux_iterm2" = true && set -a tmux_cmd -CC
+    test "$fish_tmux_unicode" = true && set -a tmux_cmd -u
 
-    if test $fish_tmux_autoconnect = true && tmux has-session
-        exec $tmux_cmd attach
+    test "$fish_tmux_detached" = true && set _detached "-d"
+
+    if test "$fish_tmux_autoname_session" = true
+        # name the session after the basename of current directory
+        set session_name (basename $PWD)
+        # if the current directory is the home directory, name it 'HOME'
+        test "$PWD" = "$HOME" && set session_name HOME
+        # if the current directory is the root directory, name it 'ROOT'
+        test "$PWD" = "/" && set session_name ROOT
     else
-        if test $fish_tmux_fixterm = true
+        set session_name "$fish_tmux_default_session_name"
+    end
+
+    # try to connect to an existing session
+    if test -n "$session_name"
+        if test "$fish_tmux_autoconnect" = true
+            $tmux_cmd attach $_detached -t $session_name
+        end
+    else
+        if test "$fish_tmux_autoconnect" = true
+            $tmux_cmd attach $_detached
+        end
+    end
+
+    # if failed, just run tmux, fixing the TERM variable if requested
+    if test $status -ne 0
+        if test "$fish_tmux_fixterm" = true
             set -a tmux_cmd -f $_fish_tmux_fixed_config
-        else if test -e $fish_tmux_config
+        else if test -e "$fish_tmux_config"
             set -a tmux_cmd -f $fish_tmux_config
         end
 
-        if set -q fish_tmux_default_session_name
-            exec $tmux_cmd new-session -s $fish_tmux_default_session_name
+        if test -n "$session_name"
+            $tmux_cmd new-session -s $session_name
         else
-            exec $tmux_cmd new-session
+            $tmux_cmd new-session
         end
+    end
+
+    if test "$fish_tmux_autoquit" = true
+        kill $fish_pid
     end
 end
 
 alias tmux=_fish_tmux_plugin_run
 
-set -q fish_tmux_autostarted || set fish_tmux_autostarted false
-if status is-interactive && ! fish_is_root_user
-    if test -z $TMUX && \
-        test $fish_tmux_autostart = true && \
-        test -z $INSIDE_EMACS && \
-        test -z $EMACS && \
-        test -z $VIM && \
-        test -z $VSCODE_RESOLVING_ENVIRONMENT && \
-        test "$TERM_PROGRAM" != 'vscode' && \
-        test "$TERM_PROGRAM" != 'zed' && \
-        test "$TERMINAL_EMULATOR" != 'JetBrains-JediTerm'
-        if test $fish_tmux_autostart_once = false || test ! $fish_tmux_autostarted = true
-            set -x fish_tmux_autostarted true
+function _fish_tmux_directory_session
+    # current directory without leading path
+    set dir (basename $PWD)
+    # md5 hash for the full working directory path
+    set md5 (echo -n $PWD | md5sum | cut -d ' ' -f 1)
+    # human friendly unique session name for this directory
+    set session_name "$dir"-(string shorten --char="" --max 6 $md5)
+    # create or attach to the session
+    tmux new -As "$session_name"
+end
+
+alias tds=_fish_tmux_directory_session
+
+# this will autostart tmux if $fish_tmux_autostart is set to `true` using the `--on-variable` function option
+function _fish_tmux_plugin_run_autostart --on-variable fish_tmux_autostart
+    if test "$fish_tmux_autostart" = true && \
+    test -z "$TMUX" && \
+    test -z "$INSIDE_EMACS" && \
+    test -z "$EMACS" && \
+    test -z "$VIM" && \
+    test -z "$NVIM" && \
+    test -z "$INTELLIJ_ENVIRONMENT_READER" && \
+    test -z "$VSCODE_RESOLVING_ENVIRONMENT" && \
+    test "$TERM_PROGRAM" != 'vscode' && \
+    test "$TERM_PROGRAM" != 'zed' && \
+    test "$TERMINAL_EMULATOR" != 'JetBrains-JediTerm'
+        set -q fish_tmux_autostart_once || set fish_tmux_autostart_once true
+
+        if test "$fish_tmux_autostart_once" = false || test ! "$fish_tmux_autostarted" = true
+            set -gx fish_tmux_autostarted true
             _fish_tmux_plugin_run
         end
     end

--- a/conf.d/tmux_abbrs.fish
+++ b/conf.d/tmux_abbrs.fish
@@ -1,6 +1,0 @@
-abbr -a ta 'tmux attach -t'
-abbr -a tad 'tmux attach -d -t'
-abbr -a ts 'tmux new-session -s'
-abbr -a tl 'tmux list-sessions'
-abbr -a tksv 'tmux kill-server'
-abbr -a tkss 'tmux kill-session -t'


### PR DESCRIPTION
BREAKING CHANGE: This is almost a complete rewrite

- use `alias` instead of `abbr` to match upstream
- added features which were added in upstream
- `$fish_tmux_autostart` is now `false` by default to match upstream
- most variables are now local to function when called instead of being globally set
- autostart feature is now a function that gets called automatically when `$fish_tmux_autostart` is changed
- plugin can now run as root just like upstream, you can change this behavior manually in your config.fish file
- removed `fish_tmux_alter_path` hack as you can now control when to run this plugin

Fixes: https://github.com/budimanjojo/tmux.fish/issues/12