### PR TITLE
fix: `tmux` does not start when `fish_tmux_autoconnect` is `false`

### DIFF
--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -128,7 +128,7 @@ function _fish_tmux_plugin_run
     end
 
     # if failed, just run tmux, fixing the TERM variable if requested
-    if test $status -ne 0
+    if test "$fish_tmux_autoconnect" = false || test $status -ne 0
         if test "$fish_tmux_fixterm" = true
             set -a tmux_cmd -f $_fish_tmux_fixed_config
         else if test -e "$fish_tmux_config"


### PR DESCRIPTION
Plugin does not attempt to run `tmux` when `fish_tmux_autoconnect` is `false`