### PR TITLE
fix: XDG_CONFIG_HOME not resolving

### DIFF
--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -4,7 +4,7 @@ set -q fish_tmux_autostarted || set -gx fish_tmux_autostarted false
 # set the configuration path
 if test -e "$HOME/.tmux.conf"
     set -q fish_tmux_config || set -gx fish_tmux_config "$HOME/.tmux.conf"
-else if test -e (set -q XDG_CONFIG_HOME || echo "$HOME/.config")/tmux/tmux.conf
+else if test -e "$(set -q XDG_CONFIG_HOME && echo $XDG_CONFIG_HOME || echo "$HOME/.config")/tmux/tmux.conf"
     set -q fish_tmux_config || set -gx fish_tmux_config (set -q XDG_CONFIG_HOME && echo $XDG_CONFIG_HOME || echo "$HOME/.config")/tmux/tmux.conf
 else
     set -q fish_tmux_config || set -gx fish_tmux_config "$HOME/.tmux.conf"

--- a/conf.d/tmux.fish
+++ b/conf.d/tmux.fish
@@ -5,7 +5,7 @@ set -q fish_tmux_autostarted || set -gx fish_tmux_autostarted false
 if test -e "$HOME/.tmux.conf"
     set -q fish_tmux_config || set -gx fish_tmux_config "$HOME/.tmux.conf"
 else if test -e (set -q XDG_CONFIG_HOME || echo "$HOME/.config")/tmux/tmux.conf
-    set -q fish_tmux_config || set -gx fish_tmux_config (set -q XDG_CONFIG_HOME || echo "$HOME/.config")/tmux/tmux.conf
+    set -q fish_tmux_config || set -gx fish_tmux_config (set -q XDG_CONFIG_HOME && echo $XDG_CONFIG_HOME || echo "$HOME/.config")/tmux/tmux.conf
 else
     set -q fish_tmux_config || set -gx fish_tmux_config "$HOME/.tmux.conf"
 end


### PR DESCRIPTION
`set -q` only checks if the variable exists, it doesn't return the value. So configurations using XDG_CONFIG_HOME break. This fixes it echoing the value if present.